### PR TITLE
add build to rtfd config and use mpich on travis

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,13 @@ sphinx:
   configuration: docs/source/conf.py
 
 # build
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# install
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
 
 # build
 build:
-  os: ubuntu-22.04
+  os: ubuntu-18.04
   tools:
     python: "3.10"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
 
 # build
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.10"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
 
 # build
 build:
-  os: ubuntu-18.04
+  os: ubuntu-20.04
   tools:
     python: "3.10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: jammy
+dist: bionic
 language: python
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-dist: jammy
+dist: xenial
+os: linux
+sudo: required
 language: python
 
 matrix:
@@ -40,11 +42,12 @@ matrix:
 
 cache:
     pip: true
+    apt: true
 
 before_install:
     - set -e  # fail on any error
     - sudo apt-get update -q
-    - set -x; sudo apt-get install -y -q openmpi-bin libopenmpi-dev
+    - set -x; sudo apt-get install -y -q mpich libmpich-dev # openmpi-bin libopenmpi-dev
     - if [[ $COVERAGE == "true" ]]; then pip install coverage; fi
     - if [[ $CYTHON == "true" ]]; then pip install "cython<0.29.25"; fi #FIXME
     - if [[ $DILL == "master" ]]; then pip install "https://github.com/uqfoundation/dill/archive/master.tar.gz"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,12 @@ matrix:
 
     allow_failures:
         - python: '3.13-dev'
+        - python: 'pypy3.9-7.3.9' # undefined symbol
         - python: 'pypy3.10-7.3.13' # CI missing
     fast_finish: true
 
 cache:
+    pip: true
     apt: true
 
 before_install:
@@ -61,7 +63,6 @@ before_install:
     - if [[ $DILL == "master" ]]; then pip install "https://github.com/uqfoundation/dill/archive/master.tar.gz"; fi
 
 install:
-    - env MPICC=$MPI_CC python -m pip install --no-cache-dir mpi4py
     - python -m pip install .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: jammy
 os: linux
 sudo: required
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 os: linux
 sudo: required
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: jammy
 language: python
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 language: python
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ matrix:
     fast_finish: true
 
 cache:
-    pip: true
     apt: true
 
 before_install:
@@ -62,6 +61,7 @@ before_install:
     - if [[ $DILL == "master" ]]; then pip install "https://github.com/uqfoundation/dill/archive/master.tar.gz"; fi
 
 install:
+    - env MPICC=$MPI_CC python -m pip install --no-cache-dir mpi4py
     - python -m pip install .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,33 +7,42 @@ matrix:
     include:
         - python: '3.8'
           env:
+            - RDMAV_FORK_SAFE=1
 
         - python: '3.9'
           env:
             - COVERAGE="true"
+            - RDMAV_FORK_SAFE=1
 
         - python: '3.10'
           env:
+            - RDMAV_FORK_SAFE=1
 
         - python: '3.11'
           env:
+            - RDMAV_FORK_SAFE=1
 
         - python: '3.12'
           env:
+            - RDMAV_FORK_SAFE=1
 
         - python: '3.13-dev'
           env:
             - CYTHON="true" # numpy source build
             - DILL="master"
+            - RDMAV_FORK_SAFE=1
 
         - python: 'pypy3.8-7.3.9' # at 7.3.11
           env:
+            - RDMAV_FORK_SAFE=1
 
         - python: 'pypy3.9-7.3.9' # at 7.3.13
           env:
+            - RDMAV_FORK_SAFE=1
 
         - python: 'pypy3.10-7.3.13'
           env:
+            - RDMAV_FORK_SAFE=1
 
     allow_failures:
         - python: '3.13-dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: focal
 language: python
 
 matrix:


### PR DESCRIPTION
## Summary
add build stanza to the readthedocs config file; use python 3.10 for doc build
switch from openmpi to mpich build on travis; update to jammy

## Checklist
**Documentation and Tests**
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.