### PR TITLE
add initial support for python 3.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,11 @@ matrix:
           env:
             - RDMAV_FORK_SAFE=1
 
-        - python: '3.13-dev'
+        - python: '3.13'
+          env:
+            - RDMAV_FORK_SAFE=1
+
+        - python: '3.14-dev'
           env:
             - CYTHON="true" # numpy source build
             - DILL="master"
@@ -45,6 +49,7 @@ matrix:
             - RDMAV_FORK_SAFE=1
 
     allow_failures:
+        - python: '3.14-dev' # CI missing
         - python: 'pypy3.9-7.3.9' # undefined symbol
         - python: 'pypy3.10-7.3.17' # CI missing
     fast_finish: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,11 @@
 # Packages required to build docs
 # dependencies pinned as:
-# https://github.com/readthedocs/readthedocs.org/blob/d3606da9907bb4cd933abcf71c7bab9eb20435cd/requirements/docs.txt
+# https://github.com/readthedocs/readthedocs.org/blob/71a82c94adbacf87b4630288f91f1a56e05f54f2/requirements/docs.txt
 
 alabaster==0.7.16
 anyio==4.4.0
 babel==2.15.0
-certifi==2024.7.4
+certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
@@ -47,10 +47,11 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
+phinxext-opengraph==0.9.1
 starlette==0.37.2
 tomli==2.0.1
 typing-extensions==4.12.1
-urllib3==2.2.2
+urllib3==2.2.1
 uvicorn==0.30.0
 watchfiles==0.22.0
 websockets==12.0

--- a/setup.py
+++ b/setup.py
@@ -166,9 +166,3 @@ You may need to set the environment variable "SDKROOT",
 as shown in the instructions for installing ``mpi4py``:
   http://mpi4py.scipy.org/docs/usrman/install.html
 """)
-
-
-if __name__=='__main__':
-    pass
-
-# End of file

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     py311
     py312
     py313
+    py314
     pypy38
     pypy39
     pypy310


### PR DESCRIPTION
## Summary
add initial support for python 3.14
Fixes: #83 

## Checklist
**Documentation and Tests**
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added rationale for any breakage of backwards compatibility.