### PR TITLE
better tests for default launcher and scheduler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,19 +44,19 @@ matrix:
           env:
             - RDMAV_FORK_SAFE=1
 
-        - python: 'pypy3.10-7.3.18'
+        - python: 'pypy3.10-7.3.19'
           env:
             - RDMAV_FORK_SAFE=1
 
-        - python: 'pypy3.11-7.3.18'
+        - python: 'pypy3.11-7.3.19'
           env:
             - RDMAV_FORK_SAFE=1
 
     allow_failures:
         - python: '3.14-dev' # CI missing
         - python: 'pypy3.9-7.3.9' # undefined symbol
-        - python: 'pypy3.10-7.3.18' # CI missing
-        - python: 'pypy3.11-7.3.18' # CI missing
+        - python: 'pypy3.10-7.3.19' # CI missing
+        - python: 'pypy3.11-7.3.19' # CI missing
     fast_finish: true
 
 cache:

--- a/examples/mpd_trace.py
+++ b/examples/mpd_trace.py
@@ -11,11 +11,17 @@ run some basic tests of the MPI installation
 
 import subprocess
 
-command = 'mpiexec -info'
+from pyina.tools import which_launcher
+mpiexec = which_launcher()
+
+if 'mpi' in mpiexec:
+    command = '%s -info' % mpiexec
+else:
+    command = '%s --version' % mpiexec
 print("\nlaunch: %s" % command)
 subprocess.call(command, shell=True)
 
-command = 'mpiexec -n 4 hostname'
+command = '%s -n 4 hostname' % mpiexec
 print("\nlaunch: %s" % command)
 subprocess.call(command, shell=True)
 

--- a/examples/pypi.py
+++ b/examples/pypi.py
@@ -37,8 +37,7 @@ integration_points = (arange(1,n+1)-0.5)/n
 def f(x):
     return 4.0/(1.0+x*x)
 
-#from pyina.launchers import MpiScatter as Mpi
-from pyina.launchers import MpiPool as Mpi
+from pyina.launchers import Pool as Mpi
 
 
 if __name__ == '__main__':
@@ -49,7 +48,7 @@ if __name__ == '__main__':
     from pyina import mpi
     if mpi.world.rank == 0:
         print("approxmiate pi : ", sum(out)/n)
-        print("calculated on %d nodes " % work.nodes)
+        print("calculated on %d nodes " % int(work.nodes))
 
 
 # end of file

--- a/examples/test_ezmap.py
+++ b/examples/test_ezmap.py
@@ -6,7 +6,8 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import MpiScatter, MpiPool
+from pyina.launchers import Pool as MpiPool, Scatter as MpiScatter
+
 
 def host(id):
     import socket

--- a/examples/test_ezmap1.py
+++ b/examples/test_ezmap1.py
@@ -6,7 +6,8 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import MpiScatter
+from pyina.launchers import Scatter as MpiScatter
+
 
 def host(id):
     import socket

--- a/examples/test_ezmap2.py
+++ b/examples/test_ezmap2.py
@@ -6,7 +6,8 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import MpiScatter, MpiPool
+from pyina.launchers import Pool as MpiPool
+
 
 def play(Q):
     id, l = Q
@@ -17,9 +18,9 @@ def play2(id,l):
     import numpy
     return "3 x %d = %d" % (id, numpy.sum(l))
 
-args = [ (i, range(3)*i) for i in range(5) ]
+args = [ (i, list(range(3))*i) for i in range(5) ]
 arg1 = [ i for i in range(5) ]
-arg2 = [ range(3)*i for i in range(5) ]
+arg2 = [ list(range(3))*i for i in range(5) ]
 
 print("Using 12 nodes and a worker pool...")
 print('Evaluate a function that expects a n-tuple argument "map(f,args)"')

--- a/examples/test_ezmap3.py
+++ b/examples/test_ezmap3.py
@@ -6,7 +6,8 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import Mpi
+from pyina.launchers import Pool as Mpi
+
 
 def host(id):
     import socket

--- a/examples/test_ezmap4.py
+++ b/examples/test_ezmap4.py
@@ -6,7 +6,8 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import Mpi
+from pyina.launchers import Pool as Mpi
+
 
 #XXX: should not have to define "func" within mapped function
 #from mystic.models import rosen as func

--- a/examples/test_ezmap5.py
+++ b/examples/test_ezmap5.py
@@ -6,7 +6,8 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import Mpi
+from pyina.launchers import Pool as Mpi
+
 
 #XXX:: can fail with NameError: global name 'func' is not defined
 #XXX:: can fail with RuntimeError: maximum recursion depth exceeded

--- a/examples/test_ezmap6.py
+++ b/examples/test_ezmap6.py
@@ -6,9 +6,12 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import SerialMapper
-from pyina.schedulers import Torque
 from pyina.mpi import _save, _debug
+from pyina.launchers import SerialMapper
+from pyina.schedulers import Torque, Sheduled
+if Scheduled != Torque:
+    print('Torque scheduler is not available')
+    exit()
 
 #_debug(True)
 #_save(True)

--- a/examples/test_ezmap7.py
+++ b/examples/test_ezmap7.py
@@ -6,9 +6,12 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import Mpi
-from pyina.schedulers import Torque
 from pyina.mpi import _save, _debug
+from pyina.launchers import Pool as Mpi
+from pyina.schedulers import Torque, Sheduled
+if Scheduled != Torque:
+    print('Torque scheduler is not available')
+    exit()
 
 #_debug(True)
 #_save(True)

--- a/examples/test_ezmap8.py
+++ b/examples/test_ezmap8.py
@@ -6,8 +6,12 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
 
-from pyina.launchers import TorqueMpiPool as Launcher
 from pyina.mpi import _save, _debug
+from pyina.launchers import TorqueMpiPool as Launcher
+from pyina.schedulers import Torque, Sheduled
+if Scheduled != Torque:
+    print('Torque scheduler is not available')
+    exit()
 
 #_debug(True)
 #_save(True)

--- a/pyina/ez_map.py
+++ b/pyina/ez_map.py
@@ -100,7 +100,15 @@ Further Input:
     if 'queue' in kwds: ezdefaults['queue'] = kwds['queue']
     # set the scheduler & launcher (or use the given default)
     if 'launcher' in kwds: launcher = kwds['launcher']
-    else: launcher = mpirun_launcher  #XXX: default = non_mpi?
+    else:
+        from pox import which
+        if which('mpirun') or which('mpiexec'):
+            launcher = mpirun_launcher
+        elif which('srun'):
+            launcher = srun_launcher
+        elif which('aprun'):
+            launcher = aprun_launcher
+        else: launcher = serial_launcher
     if 'scheduler' in kwds: scheduler = kwds['scheduler']
     else: scheduler = ''
     # set scratch directory (most often required for queue launcher)
@@ -224,7 +232,15 @@ Further Input:
     if 'queue' in kwds: ezdefaults['queue'] = kwds['queue']
     # set the scheduler & launcher (or use the given default)
     if 'launcher' in kwds: launcher = kwds['launcher']
-    else: launcher = mpirun_launcher  #XXX: default = non_mpi?
+    else:
+        from pox import which
+        if which('mpirun') or which('mpiexec'):
+            launcher = mpirun_launcher
+        elif which('srun'):
+            launcher = srun_launcher
+        elif which('aprun'):
+            launcher = aprun_launcher
+        else: launcher = serial_launcher
     if 'scheduler' in kwds: scheduler = kwds['scheduler']
     else: scheduler = ''
     # set scratch directory (most often required for queue launcher)

--- a/pyina/launchers.py
+++ b/pyina/launchers.py
@@ -80,7 +80,7 @@ __all__ = ['SerialMapper', 'ParallelMapper', 'Mpi', 'Slurm', 'Alps',
            'AlpsScatter', 'TorqueMpi', 'TorqueSlurm', 'MoabMpi', 'MoabSlurm',
            'TorqueMpiPool', 'TorqueMpiScatter', 'TorqueSlurmPool',
            'TorqueSlurmScatter', 'MoabMpiPool', 'MoabMpiScatter',
-           'MoabSlurmPool', 'MoabSlurmScatter']
+           'MoabSlurmPool', 'MoabSlurmScatter', 'Pool', 'Scatter']
 
 from pyina.mpi import Mapper, defaults
 from pathos.abstract_launcher import AbstractWorkerPool
@@ -438,6 +438,17 @@ class MoabSlurmScatter(MoabSlurm):
         MoabSlurm.__init__(self, *args, **kwds)
     pass
 
+
+# launcher defaults
+if defaults['mpirun'] == 'srun':
+    Pool = SlurmPool
+    Scatter = SlurmScatter
+elif defaults['mpirun'] == 'aprun':
+    Pool = AlpsPool
+    Scatter = AlpsScatter
+else:
+    Pool = MpiPool
+    Scatter = MpiScatter
 
 
 # backward compatibility

--- a/pyina/mpi.py
+++ b/pyina/mpi.py
@@ -74,7 +74,7 @@ from pathos.helpers import cpu_count
 import os, os.path, sys
 import tempfile
 from dill.temp import dump, dump_source
-from pyina.tools import which_python, which_mpirun, which_strategy
+from pyina.tools import which_python, which_launcher, which_strategy
 
 _HOLD = []
 _SAVE = [False]
@@ -103,7 +103,7 @@ _pid = '.' + str(os.getpid()) + '.'
 defaults = {
     'nodes' : str(cpu_count()),
     'program' : which_strategy(lazy=True) or 'ezscatter', # serialize to tempfile
-    'mpirun' : which_mpirun() or 'mpiexec',
+    'mpirun' : which_launcher() or 'mpiexec',
     'python' : which_python(lazy=True) or 'python',
     'progargs' : '',
 

--- a/pyina/schedulers.py
+++ b/pyina/schedulers.py
@@ -50,7 +50,7 @@ provides:
  scheduler_obj = scheduler()  interface
 """
 
-__all__ = ['Scheduler', 'Torque', 'Moab', 'Lsf']
+__all__ = ['Scheduler', 'Torque', 'Moab', 'Lsf', 'Scheduled']
 
 from pyina.mpi import defaults
 from subprocess import Popen, call
@@ -304,6 +304,19 @@ NOTES:
 # http://its2.unc.edu/dci_components/lsf/mpich_parallel.htm
 # http://ait.web.psi.ch/services/linux/hpc/mpich/using_mpich_gm.html
 
+
+# schedule defaults
+from pyina.tools import which_scheduler
+sched = which_scheduler()
+if sched == 'qsub':
+    Scheduled = Torque
+elif sched == 'msub':
+    Scheduled = Moab
+elif sched == 'bsub':
+    Scheduled = Lsf
+else:
+    Scheduled = Scheduler
+del sched, which_scheduler
 
 
 # backward compatibility

--- a/pyina/tests/test_map.py
+++ b/pyina/tests/test_map.py
@@ -53,13 +53,13 @@ def check_serial(source=False):
     assert res == std
 
 def check_pool(source=False):
-    from pyina.launchers import MpiPool as MPI
+    from pyina.launchers import Pool as MPI
     pool = MPI(4, source=source)
     res = timed_pool(pool, items, delay, verbose)
     assert res == std
 
 def check_scatter(source=False):
-    from pyina.launchers import MpiScatter as MPI
+    from pyina.launchers import Scatter as MPI
     pool = MPI(4, source=source)
     res = timed_pool(pool, items, delay, verbose)
     assert res == std

--- a/pyina/tests/test_pool.py
+++ b/pyina/tests/test_pool.py
@@ -26,7 +26,7 @@ def run_files(obj):
     assert _obj(1.57) == obj(1.57)
 
 def run_pool(obj):
-    from pyina.launchers import Mpi
+    from pyina.launchers import Pool as Mpi
     p = Mpi(2)
     x = [1,2,3]
     y = list(map(obj, x))

--- a/pyina/tests/test_star.py
+++ b/pyina/tests/test_star.py
@@ -165,7 +165,7 @@ def check_ready(pool, maxtries, delay, verbose=True):
 
 
 def test_pool():
-    from pyina.launchers import MpiPool as Pool
+    from pyina.launchers import Pool
     pool = Pool(nodes=4)
     check_sanity( pool )
     check_maps( pool, items, delay )

--- a/pyina/tests/test_with.py
+++ b/pyina/tests/test_with.py
@@ -54,8 +54,8 @@ def run_with_multipool(Pool): #XXX: amap and imap -- NotImplementedError
 
 
 def test_with_mpipool():
-    from pyina.launchers import MpiPool
-    run_with_multipool(MpiPool)
+    from pyina.launchers import Pool
+    run_with_multipool(Pool)
 
 
 if __name__ == '__main__':

--- a/pyina/tools.py
+++ b/pyina/tools.py
@@ -145,6 +145,40 @@ def isoformat(seconds):
     t = datetime.time(h,m,s).strftime("%H:%M:%S")
     return ("%s:" % d) + t if d else t #XXX: better convert days to hours?
 
+def which_scheduler(fullpath=False):
+    """try to autodetect an available scheduler"""
+    import os
+    from pox import which
+    progs = ['qsub', 'msub', 'bsub']
+    sched = None
+    from prog in progs:
+        sched = which(prog, ignore_errors=True)
+        if sched: break
+    if sched and not fullpath:
+        sched = os.path.split(sched)[-1]
+    return sched
+
+def which_launcher(mpi=None, fullpath=False):
+    """try to autodetect an available launcher
+
+if mpi=True only look for mpi, if False only look for non-mpi"""
+    import os
+    from pox import which
+    progs = ['srun', 'aprun']
+    if mpi == True:
+        return which_mpirun(fullpath=fullpath)
+    elif mpi != False:
+        mpi = which_mpirun(fullpath=fullpath)
+        if mpi: return mpi
+    # is non-mpi
+    mpi = None
+    for prog in progs:
+        mpi = which(prog, ignore_errors=True)
+        if mpi: break
+    if mpi and not fullpath:
+        mpi = os.path.split(mpi)[-1]
+    return mpi #XXX: if None, use serial?
+
 def which_mpirun(mpich=None, fullpath=False):
     """try to autodetect an available mpi launcher
 

--- a/pyina/tools.py
+++ b/pyina/tools.py
@@ -151,7 +151,7 @@ def which_scheduler(fullpath=False):
     from pox import which
     progs = ['qsub', 'msub', 'bsub']
     sched = None
-    from prog in progs:
+    for prog in progs:
         sched = which(prog, ignore_errors=True)
         if sched: break
     if sched and not fullpath:


### PR DESCRIPTION
## Summary
add `which_launcher` and `which_scheduler` to better detect the if there is an available launcher and scheduler, respectively.

Update examples and tests to use autodetected launcher and scheduler, where relevant


## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [x] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.