### PR TITLE
drop formal support for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ language: python
 
 matrix:
     include:
-        - python: '3.8'
-          env:
-            - RDMAV_FORK_SAFE=1
-
         - python: '3.9'
           env:
             - COVERAGE="true"
@@ -34,10 +30,6 @@ matrix:
           env:
             - CYTHON="true" # numpy source build
             - DILL="master"
-            - RDMAV_FORK_SAFE=1
-
-        - python: 'pypy3.8-7.3.9' # at 7.3.11
-          env:
             - RDMAV_FORK_SAFE=1
 
         - python: 'pypy3.9-7.3.9' # at 7.3.16

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Requirements
 ------------
 ``pyina`` requires:
 
-* ``python`` (or ``pypy``), **>=3.8**
+* ``python`` (or ``pypy``), **>=3.9**
 * ``setuptools``, **>=42**
 * ``cython``, **>=0.29.30**
 * ``numpy``, **>=1.0**

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@
 import os
 import sys
 # drop support for older python
-if sys.version_info < (3, 8):
-    unsupported = 'Versions of Python before 3.8 are not supported'
+if sys.version_info < (3, 9):
+    unsupported = 'Versions of Python before 3.9 are not supported'
     raise ValueError(unsupported)
 
 # get distribution meta info
@@ -74,14 +74,13 @@ setup_kwds = dict(
         'Source Code':'https://github.com/uqfoundation/pyina',
         'Bug Tracker':'https://github.com/uqfoundation/pyina/issues',
     },
-    python_requires = '>=3.8',
+    python_requires = '>=3.9',
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,15 @@
 skip_missing_interpreters=
     True
 envlist =
-    py38
     py39
     py310
     py311
     py312
     py313
     py314
-    pypy38
     pypy39
     pypy310
+    pypy311
 
 [testenv]
 deps =


### PR DESCRIPTION
## Summary
drop formal support for python 3.8
Closes: #82 
