### PR TITLE
explicit tasks versus nodes within scheduler and launcher

### DIFF
--- a/pyina/launchers.py
+++ b/pyina/launchers.py
@@ -104,6 +104,12 @@ Mapper base class for pipe-based mapping with python.
         self.nodes = 1 # always has one node... it's serial!
         return
     __init__.__doc__ = Mapper.__init__.__doc__
+    def njobs(self, nodes):
+        """convert node_string intended for scheduler to '1'
+
+ignores node string and returns 1, as mapper is serial.
+        """
+        return 1
     def _launcher(self, kdict={}):
         """prepare launch command for pipe-based execution
 
@@ -128,6 +134,14 @@ NOTES:
             scheduler = "None"
         mapargs = (self.__class__.__name__, scheduler)
         return "<pool %s(scheduler=%s)>" % mapargs
+    def _tasks(self, nodes=None):
+        if nodes is None: return self.nodes
+        return nodes
+    def _nodes(self, tasks=None):
+        if tasks is None: tasks = self.nodes
+        if isinstance(tasks, type('')) and tasks.startswith(('"',"'")):
+            tasks = tasks[1:-1]
+        return tasks
     pass
 
 #FIXME: enable user to override 'mpirun'
@@ -151,17 +165,29 @@ for the associated launcher (e.g mpirun, mpiexec).
        #self.nodes = kwds.get('nodes', None)
         if not len(args) and 'nodes' not in kwds:
             if self.scheduler:
-                self.nodes = self.scheduler.nodes
+                self.nodes = self.scheduler._nodes()
             else:
                 self.nodes = cpu_count()
         return
     if AbstractWorkerPool.__init__.__doc__: __init__.__doc__ = AbstractWorkerPool.__init__.__doc__ + __init__.__doc__
     def njobs(self, nodes):
-        """convert node_string intended for scheduler to int number of nodes
+        """convert node_string intended for scheduler to number of nodes
 
-compute int from node string. For example, parallel.njobs("4") yields 4
+compute nodes from node string. For example, parallel.njobs("4") yields 4.
+Node string accepts fine-grained controls ('ppn=' and 'cpp=') as a multiplier
         """
-        return int(str(nodes)) #XXX: this is a dummy function
+        nodestr = str(nodes)
+        if nodestr.startswith(('"',"'")): nodestr = nodestr[1:-1]
+        nodestr = nodestr.split(",")[0]  # remove appended -l expressions
+        nodelst = nodestr.split(":")
+        if ':ppn=' not in nodestr and ':cpp=' not in nodestr: return nodestr
+        n = int(nodelst[0])
+        ppn = 1
+        for i in nodelst:
+            if i.startswith(('ppn=','cpp=')): #XXX: 'N=' has no impact
+                ppn *= int(i.split('=')[1])
+        tasks = n*ppn
+        return str(tasks)
     def _launcher(self, kdict={}):
         """prepare launch command for pipe-based execution
 
@@ -185,7 +211,15 @@ NOTES:
         else:
             scheduler = "None"
         mapargs = (self.__class__.__name__, self.nodes, scheduler)
-        return "<pool %s(ncpus=%s, scheduler=%s)>" % mapargs
+        return "<pool %s(nodes='%s', scheduler=%s)>" % mapargs
+    def _tasks(self, nodes=None):
+        if nodes is None: return self.nodes
+        return self.njobs(nodes)
+    def _nodes(self, tasks=None):
+        if tasks is None: tasks = self.nodes
+        if isinstance(tasks, type('')) and tasks.startswith(('"',"'")):
+            tasks = tasks[1:-1]
+        return tasks
     def __get_nodes(self):
         """get the number of nodes in the pool"""
         return self.__nodes
@@ -201,26 +235,28 @@ class Mpi(ParallelMapper):
     """
     """
     def njobs(self, nodes):
-        """convert node_string intended for scheduler to mpirun node_string
+        """convert node_string intended for scheduler to mpirun task_string
 
 compute mpirun task_string from node string of pattern = N[:TYPE][:ppn=P]
-For example, mpirun.njobs("3:core4:ppn=2") yields 6
+For example, mpirun.njobs("3:core4:ppn=2") yields 6.
+Node string accepts fine-grained controls ('ppn=' and 'cpp=') as a multiplier
         """
         nodestr = str(nodes)
+        if nodestr.startswith(('"',"'")): nodestr = nodestr[1:-1]
         nodestr = nodestr.split(",")[0]  # remove appended -l expressions
         nodelst = nodestr.split(":")
+        if ':ppn=' not in nodestr and ':cpp=' not in nodestr: return nodestr
         n = int(nodelst[0])
-        nodelst = nodestr.split("ppn=")
-        if len(nodelst) > 1:
-            ppn = nodelst[1]
-            ppn = int(ppn.split(":")[0])
-        else: ppn = 1
-        tasks =  n*ppn
-        return tasks
+        ppn = 1
+        for i in nodelst:
+            if i.startswith(('ppn=','cpp=')): #XXX: 'N=' has no impact
+                ppn *= int(i.split('=')[1])   #XXX: no standard threads/nodes
+        tasks = n*ppn
+        return str(tasks)
     def _launcher(self, kdict={}):
         """prepare launch command for parallel execution using mpirun
 
-equivalent to:  mpiexec -np (nodes) (python) (program) (progargs)
+equivalent to:  mpiexec -np (tasks) (python) (program) (progargs)
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
@@ -241,28 +277,33 @@ NOTES:
 class Slurm(ParallelMapper):
     """
     """
-    def njobs(self, nodes):
-        """convert node_string intended for scheduler to srun node_string
+    def njobs(self, nodes): #FIXME: not consistent with Mpi/Parallel
+        """convert node_string intended for scheduler to srun task_string
 
 compute srun task_string from node string of pattern = N[:ppn=P][,partition=X]
-For example, srun.njobs("3:ppn=2,partition=foo") yields '3 -N2'
-        """
-        nodestr = str(nodes)
-        nodestr = nodestr.split(",")[0]  # remove appended -l expressions
-        nodelst = nodestr.split(":")
-        n = int(nodelst[0])
-        nodelst = nodestr.split("ppn=")
-        if len(nodelst) > 1:
-            ppn = nodelst[1]
-            ppn = int(ppn.split(":")[0])
-            tasks = "%s -N%s" % (n, ppn)
+For example, srun.njobs("6:ppn=2") yields '12 -N6 --ntasks-per-node=2'.
+Node string accepts fine-grained controls, and ('cpp=') a multiplier
+        """ # CPUS == NTASKS(nodes * ntasks-per-node) * cpus-per-task
+        if nodes is None: nodes = str(nodes) #XXX: ungraceful fail
+        return Sbatch()._tasks(nodes)
+    def __repr__(self):
+        if self.scheduler:
+            scheduler = self.scheduler.__class__.__name__
         else:
-            tasks = "%s" % n
-        return tasks
+            scheduler = "None"
+        nodes = self._nodes()
+        mapargs = (self.__class__.__name__, nodes, scheduler)
+        return "<pool %s(nodes='%s', scheduler=%s)>" % mapargs
+    def _tasks(self, nodes=None):
+        if nodes is None: return self.nodes
+        return self.njobs(nodes)
+    def _nodes(self, tasks=None):
+        if tasks is None: tasks = self.nodes
+        return "%s" % Sbatch()._nodes(tasks)
     def _launcher(self, kdict={}):
         """prepare launch for parallel execution using srun
 
-equivalent to:  srun -n(nodes) (python) (program) (progargs)
+equivalent to:  srun -n(tasks) (python) (program) (progargs)
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
@@ -274,6 +315,9 @@ NOTES:
        #    mydict['nodes'] = self.njobs()
         str =  """srun -n%(nodes)s %(python)s %(program)s %(progargs)s""" % mydict
         if self.scheduler:
+            #if isinstance(self.scheduler, Sbatch): # split tasks and nodes
+            #    mydict['tasks'] = self.scheduler._jobs(mydict['nodes'])
+            #    str =  """srun -n%(tasks)s %(python)s %(program)s %(progargs)s""" % mydict #NOTE: srun inherits from sbatch (so no need to repeat flags)
             str = self.scheduler._submit(str)
         return str
     def map(self, func, *args, **kwds):
@@ -284,28 +328,78 @@ NOTES:
 class Alps(ParallelMapper):
     """
     """
-    def njobs(self, nodes):
-        """convert node_string intended for scheduler to aprun node_string
+    def njobs(self, nodes): #FIXME: not consistent with Mpi/Parallel
+        """convert node_string intended for scheduler to aprun task_string
 
 compute aprun task_string from node string of pattern = N[:TYPE][:ppn=P]
-For example, aprun.njobs("3:core4:ppn=2") yields '3 -N 2'
+For example, aprun.njobs("3:core4:ppn=2") yields '6 -N 2'.
+Node string accepts fine-grained controls, and ('cpp=') a multiplier
         """
         nodestr = str(nodes)
+        if nodestr.startswith(('"',"'")): nodestr = nodestr[1:-1]
         nodestr = nodestr.split(",")[0]  # remove appended -l expressions
         nodelst = nodestr.split(":")
+        if ':ppn=' not in nodestr and ':cpp=' not in nodestr: return nodestr
         n = int(nodelst[0])
-        nodelst = nodestr.split("ppn=")
-        if len(nodelst) > 1:
-            ppn = nodelst[1]
-            ppn = int(ppn.split(":")[0])
-            tasks = "%s -N %s" % (n, ppn)
+        ppn = None
+        cpp = None
+        for i in nodelst:
+            if i.startswith('ppn='): #XXX: doesn't handle 'N='
+                ppn = int(i.split('=')[1])
+            elif i.startswith('cpp='):
+                cpp = int(i.split('=')[1])
+        tasks = ""
+        if cpp is not None:
+            tasks += " -d %s" % cpp
+        if ppn is not None:
+            tasks += " -N %s" % ppn
+            n *= ppn
+        tasks = ''.join(["%s" % n, tasks])
+        return tasks #XXX: is str --> '3 -d 2 -N 1" --> 6 jobs into 6 nodes
+    def __repr__(self):
+        if self.scheduler:
+            scheduler = self.scheduler.__class__.__name__
         else:
-            tasks = "%s" % n
-        return tasks
+            scheduler = "None"
+        nodes = self._nodes()
+        mapargs = (self.__class__.__name__, nodes, scheduler)
+        return "<pool %s(nodes='%s', scheduler=%s)>" % mapargs
+    def _tasks(self, nodes=None):
+        if nodes is None: return self.nodes
+        return self.njobs(nodes)
+    def _nodes(self, tasks=None):
+        if tasks is None: tasks = self.nodes
+        nodes = tasks
+        #XXX: short-circuit if missing required string contents?
+        nrepr = None
+        nproc = 1
+        if isinstance(nodes, type("")):
+            if ' -N ' in nodes:
+                nrepr = nodes.replace(' -N ', ':ppn=')
+                nodes,nproc = nodes.split(' -N ')
+                nproc = int(nproc.strip())
+            ## roll into single int ##
+            #n = 1
+            #for i in nodes.split(' -d '):
+            #    n *= int(i)
+            #nodes = n
+            if ' -d ' in nodes:
+                if nrepr is None: nrepr = nodes
+                nrepr = nrepr.replace(' -d ', ':cpp=').strip()
+                nodes,nrepr = nrepr.split(':',1)
+                nrepr = ':'.join(['%s' % (int(nodes.strip())//nproc), nrepr])
+                nodes = "'%s'" % nrepr.strip()
+            else:
+                if nrepr is None: nodes = int(nodes.strip())
+                else:
+                    nodes = int(nodes.strip())//nproc
+                    nodes = ("'%s:ppn=%s'" % (nodes, nproc)).strip()
+        if isinstance(nodes, type('')) and nodes.startswith(('"',"'")): nodes = nodes[1:-1]
+        return nodes
     def _launcher(self, kdict={}):
         """prepare launch for parallel execution using aprun
 
-equivalent to:  aprun -n (nodes) (python) (program) (progargs)
+equivalent to:  aprun -n (tasks) (python) (program) (progargs)
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
@@ -512,7 +606,7 @@ For example, mpirun_tasks("3:core4:ppn=2") yields 6
     return mapper.njobs(nodes)
 
 
-def srun_tasks(nodes):
+def srun_tasks(nodes):#, split=False):
     """
 Helper function.
 compute srun task_string from node string of pattern = N[:ppn=P][,partition=X]
@@ -520,13 +614,16 @@ For example, srun_tasks("3:ppn=2,partition=foo") yields '3 -N2'
     """
     mapper = Slurm()
     return mapper.njobs(nodes)
+    #tasks = mapper.njobs(nodes)
+    #if not split: return tasks
+    #return mapper._tasks(tasks)
 
 
 def aprun_tasks(nodes):
     """
 Helper function.
 compute aprun task_string from node string of pattern = N[:TYPE][:ppn=P]
-For example, aprun_tasks("3:core4:ppn=2") yields '3 -N 2'
+For example, aprun_tasks("3:core4:ppn=2") yields '6 -N 2'
     """
     mapper = Alps()
     return mapper.njobs(nodes)
@@ -559,7 +656,7 @@ NOTES:
 def srun_launcher(kdict={}):
     """
 prepare launch for parallel execution using srun
-syntax:  srun -n(nodes) (python) (program) (progargs)
+syntax:  srun -n(tasks) (python) (program) (progargs)
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
@@ -572,7 +669,7 @@ NOTES:
 def aprun_launcher(kdict={}):
     """
 prepare launch for parallel execution using aprun
-syntax:  aprun -n(nodes) (python) (program) (progargs)
+syntax:  aprun -n(tasks) (python) (program) (progargs)
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
@@ -586,14 +683,14 @@ def sbatch_launcher(kdict={}): #FIXME: update
     """
 prepare launch for sbatch submission using mpiexec, srun, aprun, or serial
 
-syntax:  sbatch -N (nodes) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"mpiexec -np (nodes) (python) (program) (progargs)\"
-syntax:  sbatch -N (nodes) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"srun -n(nodes) (python) (program) (progargs)\"
-syntax:  sbatch -N (nodes) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"aprun -n (nodes) (python) (program) (progargs)\"
-syntax:  sbatch -N (nodes) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"(python) (program) (progargs)\"
+syntax:  sbatch -n (tasks) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"mpiexec -np (nodes) (python) (program) (progargs)\"
+syntax:  sbatch -n (tasks) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"srun -n(tasks) (python) (program) (progargs)\"
+syntax:  sbatch -n (tasks) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"aprun -n (tasks) (python) (program) (progargs)\"
+syntax:  sbatch -n (tasks) -t (timelimit) -o (outfile) -e (errfile) --qos=(queue) --partition=(queue) --reservation=(queue) --wrap=\"(python) (program) (progargs)\"
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
-    fine-grained resource utilization with: {'nodes':'4:nodetype:ppn=1', ...}
+    fine-grained resource utilization with: {'nodes':'4:ppn=1:cpp=2', ...}
     fine-grained resource allocation with: {'queue':'debug:partition=fast', ...}
     """
     mydict = defaults.copy()
@@ -603,15 +700,23 @@ NOTES:
     mydict['queue'] = sbatch_queue(mydict['queue'])
     if mydict['scheduler'] == sbatch.srun:
         mydict['tasks'] = srun_tasks(mydict['nodes'])
-        str = '''sbatch -N %(nodes)s -t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"srun -n%(tasks)s %(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
+        nodes = mydict['nodes']
+        mydict['nodes'] = ('-n %s ' % nodes) if nodes else ''
+        str = '''sbatch %(nodes)s-t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"srun -n%(tasks)s %(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
     elif mydict['scheduler'] == sbatch.mpirun:
         mydict['tasks'] = mpirun_tasks(mydict['nodes'])
-        str = '''sbatch -N %(nodes)s -t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"%(mpirun)s -np %(tasks)s %(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
+        nodes = mydict['nodes']
+        mydict['nodes'] = ('-n %s ' % nodes) if nodes else ''
+        str = '''sbatch %(nodes)s-t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"%(mpirun)s -np %(tasks)s %(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
     elif mydict['scheduler'] == sbatch.aprun:
         mydict['tasks'] = aprun_tasks(mydict['nodes'])
-        str = '''sbatch -N %(nodes)s -t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"aprun -n %(tasks)s %(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
+        nodes = mydict['nodes']
+        mydict['nodes'] = ('-n %s ' % nodes) if nodes else ''
+        str = '''sbatch %(nodes)s-t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"aprun -n %(tasks)s %(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
     else:  # non-mpi launch
-        str = '''sbatch -N %(nodes)s -t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"%(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
+        nodes = mydict['nodes']
+        mydict['nodes'] = ('-n %s ' % nodes) if nodes else ''
+        str = '''sbatch %(nodes)s-t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"%(python)s %(program)s %(progargs)s\" &> %(jobfile)s''' % mydict
     return str
 
 
@@ -619,13 +724,13 @@ def torque_launcher(kdict={}): #FIXME: update
     """
 prepare launch for torque submission using mpiexec, srun, aprun, or serial
 syntax:  echo \"mpiexec -np (nodes) (python) (program) (progargs)\" | qsub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
-syntax:  echo \"srun -n(nodes) (python) (program) (progargs)\" | qsub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
-syntax:  echo \"aprun -n (nodes) (python) (program) (progargs)\" | qsub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
+syntax:  echo \"srun -n(tasks) (python) (program) (progargs)\" | qsub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
+syntax:  echo \"aprun -n (tasks) (python) (program) (progargs)\" | qsub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
 syntax:  echo \"(python) (program) (progargs)\" | qsub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
-    fine-grained resource utilization with: {'nodes':'4:nodetype:ppn=1', ...}
+    fine-grained resource utilization with: {'nodes':'4:ppn=1:cpp=2', ...}
     """
     mydict = defaults.copy()
     mydict.update(kdict)
@@ -648,9 +753,9 @@ NOTES:
 def moab_launcher(kdict={}): #FIXME: update
     """
 prepare launch for moab submission using srun, mpirun, aprun, or serial
-syntax:  echo \"srun -n(nodes) (python) (program) (progargs)\" | msub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
+syntax:  echo \"srun -n(tasks) (python) (program) (progargs)\" | msub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
 syntax:  echo \"%(mpirun)s -np (nodes) (python) (program) (progargs)\" | msub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
-syntax:  echo \"aprun -n (nodes) (python) (program) (progargs)\" | msub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
+syntax:  echo \"aprun -n (tasks) (python) (program) (progargs)\" | msub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
 syntax:  echo \"(python) (program) (progargs)\" | msub -l nodes=(nodes) -l walltime=(timelimit) -o (outfile) -e (errfile) -q (queue)
 
 NOTES:

--- a/pyina/mpi.py
+++ b/pyina/mpi.py
@@ -103,7 +103,7 @@ _pid = '.' + str(os.getpid()) + '.'
 defaults = {
     'nodes' : str(cpu_count()),
     'program' : which_strategy(lazy=True) or 'ezscatter', # serialize to tempfile
-    'mpirun' : which_launcher() or 'mpiexec',
+    'mpirun' : which_launcher(mpi=True) or which_launcher() or 'mpiexec',
     'python' : which_python(lazy=True) or 'python',
     'progargs' : '',
 

--- a/pyina/schedulers.py
+++ b/pyina/schedulers.py
@@ -182,9 +182,24 @@ equivalent to:  (command)
         if not which(executable):
             raise IOError("launch failed: %s not found" % executable)
         return Popen([command], shell=True) #FIXME: shell=True is insecure
+    def _tasks(self, nodes=None):
+        if nodes is None: nodes = self.nodes
+        return nodes
+    def _nodes(self, tasks=None):
+        if tasks is None: tasks = self.nodes
+        return tasks
     def __repr__(self):
-        subargs = (self.__class__.__name__, self.nodes, self.timelimit, self.queue)
-        return "<scheduler %s(nodes=%s, timelimit=%s, queue=%s)>" % subargs
+        if isinstance(self.nodes, type("")):
+            nodes = "%s" % self._nodes() #XXX: changed so always "'%s'"
+        else: nodes = self.nodes
+        if isinstance(self.timelimit, type("")):
+            timelimit = "'%s'" % self.timelimit
+        else: timelimit = self.timelimit
+        if isinstance(self.queue, type("")):
+            queue = "'%s'" % self.queue
+        else: queue = self.queue
+        subargs = (self.__class__.__name__, nodes, timelimit, queue)
+        return "<scheduler %s(nodes='%s', timelimit=%s, queue=%s)>" % subargs
     # interface
     settings = property(__settings) #XXX: set?
     pass
@@ -249,10 +264,71 @@ Scheduler that leverages the lsf scheduler.
         self.mpich = mpich
         return
     __init__.__doc__ = Scheduler.__init__.__doc__
+    def _tasks(self, nodes=None):
+        if nodes is None: nodes = self.nodes
+
+        # short-circuit if already in correct form
+        if not isinstance(nodes, type('')): return nodes
+        if ' -R ' in nodes: return nodes
+
+        # extract n, ppn, cpp
+        nodestr = str(nodes) #XXX: N=X, where can have X=1,2
+        nodelst = nodestr.split(":")
+        n = int(nodelst[0])
+        nodes = ppn = cpp = None
+        for i in nodelst:
+            if i.startswith('ppn='):
+                ppn = int(i.split('=')[1])
+            elif i.startswith('cpp='):
+                cpp = int(i.split('=')[1])
+
+        # prepare task string from n,ppn,cpp
+        tasks = ''
+        if cpp is not None:
+            tasks += ' -R "affinity[core(%s)]"' % cpp
+        tasks += ' -R "span[hosts=%s' % n
+        if ppn is not None:
+            tasks += ',ptile=%s]"' % ppn
+            n *= ppn
+        else:
+            tasks += ']"'
+        return "".join(["%s" % n, tasks])
+    def _nodes(self, tasks=None):
+        if tasks is None: tasks = self.nodes
+
+        # short-circuit if already in correct form
+        if not isinstance(tasks, type('')): return tasks
+
+        # split on '-R'
+        _tasks = [n.strip() for n in tasks.split('-R')]
+
+        # first argument has to be tasks
+        task = _tasks[0].split()[0]
+
+        # find argument that contains 'ptile='
+        ppn = [i for i in _tasks if 'ptile=' in i][-1] if 'ptile=' in tasks else None
+        # extract ppn from ptile
+        if ppn: ppn = [i.split('=')[-1].strip() for i in ppn.split('[')[-1].split(']')[0].split(',') if 'ptile' in i][0]
+
+        # find argument that contains 'hosts='
+        n = [i for i in _tasks if 'hosts=' in i][-1] if 'hosts=' in tasks else None
+        # extract n from hosts
+        if n: n = [i.split('=')[-1].strip() for i in n.split('[')[-1].split(']')[0].split(',') if 'hosts' in i][0]
+
+        # find argument that contains 'affinity' / 'core'
+        cpp = [i for i in _tasks if 'core(' in i][-1] if 'core(' in tasks else None
+        # extract cpp from core and affinity
+        if cpp: cpp = [i.split(',')[0].split('(')[-1].split(')')[0].strip() for i in cpp.split('[')[-1].split(']')[0].split(':') if 'core' in i][0]
+
+        # build node string
+        cpp = ':cpp=%s' % cpp if cpp else ''
+        cpp = ''.join([cpp, (':ppn=%s' % ppn) if ppn else ''])
+        ppn = n if n else (("%s" % int(task)//int(ppn)) if ppn else task)
+        return (ppn + cpp) if cpp else ppn
     def _submit(self, command, kdict={}):
         """prepare the given command for submission with bsub
 
-equivalent to:  bsub -K -W (timelimit) -n (nodes) -o (outfile) -e (errfile) -q (queue) -J (progname) "(command)"
+equivalent to:  bsub -K -W (timelimit) -n (tasks) -o (outfile) -e (errfile) -q (queue) -J (progname) "(command)"
 
 NOTES:
     if mpich='mx', uses "-a mpich_mx mpich_mx_wrapper" instead of given launcher
@@ -292,6 +368,8 @@ NOTES:
         else:
             mydict['command'] = command #'"' + command + '"'
             mydict['esubapp'] = ""
+        mydict['nodes'] = self._tasks(mydict['nodes'])
+        # nodes is of the form: '50 -R "span[ptile=5]" -R "affinity[core(2)]"'
         str = """bsub -K -W %(timelimit)s -n %(nodes)s -o %(outfile)s -e %(errfile)s -q %(queue)s -J %(progname)s %(esubapp)s %(command)s &> %(jobfile)s""" % mydict
         return str
     def submit(self, command):
@@ -314,7 +392,7 @@ Scheduler that leverages the slurm sbatch scheduler.
     def _submit(self, command, kdict={}):
         """prepare the given command for submission with sbatch
 
-equivalent to:  sbatch -N (nodes) -t (timelimit) -o (outfile) -e (errfile) -q (queue) -p (queue) --reservation=(queue) --wrap=\"(command)\"
+equivalent to:  sbatch -n (tasks) -t (timelimit) -o (outfile) -e (errfile) -q (queue) -p (queue) --reservation=(queue) --wrap=\"(command)\"
 
 NOTES:
     run non-python commands with: {'python':'', ...} 
@@ -322,13 +400,80 @@ NOTES:
     fine-grained resource allocation with: {'queue':'debug:partition=fast', ...}
         """
         mydict = self.settings.copy()
-        mydict['queue'] = self._queue(mydict['queue']) # prep queue flags
         mydict.update(kdict) #XXX: parse nodes if 'ppn=x' provided
-        str = '''sbatch -N %(nodes)s -t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"''' % mydict + command + '''\" &> %(jobfile)s''' % mydict
+        mydict['queue'] = self._queue(mydict['queue'])
+        mydict['nodes'] = self._tasks(mydict['nodes'])
+        #mydict['nodes'] = self._nnodes(mydict['nodes'], command)
+        str = '''sbatch -n %(nodes)s -t %(timelimit)s -o %(outfile)s -e %(errfile)s %(queue)s --wrap=\"''' % mydict + command + '''\" &> %(jobfile)s''' % mydict
         return str
+    def _tasks(self, nodes=None):
+        if nodes is None: nodes = self.nodes
+        nodestr = str(nodes) #XXX: N=X, where can have X=1-4 or X=1,2,3
+        if nodestr.startswith(('"',"'")): nodestr = nodestr[1:-1]
+        # short-circuit if missing required string contents?
+        if ':ppn=' not in nodestr and ':cpp=' not in nodestr: return nodes
+        #nodestr = nodestr.split(",")[0]  # remove appended -l expressions
+        nodelst = nodestr.split(":")
+        n = int(nodelst[0])
+        nodes = ppn = cpp = None
+        for i in nodelst:
+            if i.startswith('ppn='):
+                ppn = int(i.split('=')[1])
+            elif i.startswith('cpp='):
+                cpp = int(i.split('=')[1])
+            #elif i.startswith('N='):
+            #    nodes = int(i.split('=')[1])
+        tasks = ""
+        if cpp is not None:
+            tasks += " --cpus-per-task=%s" % cpp
+        #if nodes is not None:
+        tasks += " -N%s" % n # nodes
+        if ppn is not None:
+            tasks += " --ntasks-per-node=%s" % ppn
+            n *= ppn
+        tasks = "".join(["%s" % n, tasks])
+        return tasks
+    def _nodes(self, tasks=None):
+        if tasks is None: tasks = self.nodes
+        nodes = tasks
+        nrepr = None
+        nproc = 1
+        ncpus = None
+        if isinstance(nodes, type("")):
+            # short-circuit if missing required string contents?
+            if ':ppn=' in nodes or ':cpp=' in nodes: return nodes
+            if ' --ntasks-per-node' in nodes:
+                nrepr = nodes.replace(' --ntasks-per-node', ':ppn')
+                nodes,nproc = nodes.split(' --ntasks-per-node=')
+                nproc = int(nproc.strip())
+            if ' -N' in nodes:
+                nodes,ncpus = nodes.split(' -N')
+                ncpus = int(ncpus.strip())
+                if nrepr is not None:
+                    nrepr = nrepr.replace(' -N%s' % ncpus, '')
+            ## roll into single int ##
+            #n = 1
+            #for i in nodes.split(' --cpus-per-task='):
+            #    n *= int(i)
+            #nodes = n
+            if ' --cpus-per-task' in nodes:
+                if nrepr is None: nrepr = nodes
+                nrepr = nrepr.replace(' --cpus-per-task', ':cpp').strip()
+                nodes,nrepr = nrepr.split(':',1)
+                nodes = (int(nodes.strip())//nproc) if ncpus is None else ncpus
+                nrepr = ':'.join(['%s' % nodes, nrepr])
+                nodes = "'%s'" % nrepr.strip()
+            else:
+                if nrepr is None: nodes = int(nodes.strip())
+                else:
+                    nodes = (int(nodes.strip())//nproc) if ncpus is None else ncpus
+                    nodes = ("'%s:ppn=%s'" % (nodes, nproc)).strip()
+        if isinstance(nodes, type('')) and nodes.startswith(("'",'"')): nodes = nodes[1:-1]
+        return nodes
     def _queue(self, queue):
         """parse the given queue string into reservation, partition, qos
         """
+        if queue.startswith('--'): return queue # is already in the right form
         qstr = queue.split(":")
         qall = [s for s in qstr if '=' not in s]
         qdict = dict(reservation=qall[-1], partition=qall[-1], qos=qall[-1]) if qall else {}
@@ -337,6 +482,27 @@ NOTES:
         if 'p' in qdict: qdict['partition'] = qdict.pop('p')
         if 'q' in qdict: qdict['qos'] = qdict.pop('q')
         return ' '.join(['--'+k+'='+v for k,v in qdict.items()])
+    def _jobs(self, nodes):
+        return self._ntasks(nodes)[0]
+    def _nnodes(self, nodes, command):
+        if command.startswith('srun '): # split tasks and nodes
+            nodes = self._ntasks(nodes)[-1]
+            return ('-N %s ' % nodes) if nodes else ''
+        return ('-N %s ' % nodes) if nodes else ''
+    def _ntasks(self, nodes):
+        if isinstance(nodes, int):
+            return str(nodes), ''
+        nodes = nodes.split()
+        if len(nodes) < 2:
+            tasks = ' '.join(nodes)
+            jobs = ''
+        elif nodes[1].startswith('--cpus-per-task='):
+            tasks = ' '.join(nodes[:2])
+            jobs = ' '.join(nodes[2:])
+        else:
+            tasks = nodes[0]
+            jobs = ' '.join(nodes[1:])
+        return tasks, jobs
     def submit(self, command):
         Scheduler.submit(self, command)
         return

--- a/pyina/tests/test_tasks.py
+++ b/pyina/tests/test_tasks.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2026 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/pyina/blob/master/LICENSE
+
+from pyina.schedulers import *
+from pyina.launchers import *
+
+nodes = '10:cpp=2:ppn=5'
+nodes_ = '10:ppn=5:cpp=2'
+_nodes = "'10:cpp=2:ppn=5'"
+
+tasks = '50 -R "span[ptile=5,hosts=10]" -R "affinity[core(2)]"'
+tasks_ = '50 -R "affinity[core(2)]" -R "span[hosts=10,ptile=5]"'
+_tasks = '50 -d 2 -N 5'
+_tasks_ = '50 --cpus-per-task=2 -N10 --ntasks-per-node=5'
+
+scheduler = Lsf(nodes)
+launcher = Alps(scheduler=scheduler)
+assert launcher._nodes() == scheduler._nodes()
+assert launcher._tasks() == _tasks
+assert scheduler._tasks() == tasks_
+
+scheduler = Lsf(tasks)
+launcher = Alps(scheduler=scheduler)
+assert launcher._nodes() == scheduler._nodes()
+assert launcher._tasks() == _tasks
+assert scheduler._tasks() == tasks
+
+scheduler = Sbatch(nodes)
+launcher = Slurm(scheduler=scheduler)
+assert launcher._nodes() == scheduler._nodes()
+assert launcher._tasks() == scheduler._tasks()
+
+scheduler = Sbatch(_tasks_)
+launcher = Slurm(scheduler=scheduler)
+assert launcher._nodes() == scheduler._nodes()
+assert launcher._tasks() == scheduler._tasks()
+
+scheduler = Torque(nodes)
+launcher = Slurm(scheduler=scheduler)
+assert launcher._nodes() == scheduler._nodes()
+assert launcher._tasks() == _tasks_
+assert scheduler._tasks() == nodes
+
+scheduler = Torque(nodes)
+launcher = Alps(scheduler=scheduler)
+assert launcher._nodes() == scheduler._nodes()
+assert launcher._tasks() == _tasks
+assert scheduler._tasks() == nodes


### PR DESCRIPTION
## Summary
add a `_tasks` and a `_nodes` method to the launchers and schedulers to make it explicit whether a node string is being produced or a task string.  Submit and launch always use the task string while __repr__ uses the node string.  Should fix any bugs when launcher is inheriting "nodes" from the scheduler.